### PR TITLE
[dataloader] add truth information

### DIFF
--- a/preprocessing/dataloader_delphes.py
+++ b/preprocessing/dataloader_delphes.py
@@ -113,6 +113,42 @@ SCHEMA={
         }, # prepare the output variables
         ["ta_pt","ta_eta","ta_phi","ta_m","ta_ch"], # the actual saved one and the order
     ],
+    "genparticles":[
+       12,
+       {
+         'pt': 'Particle/Particle.PT',
+         'eta': 'Particle/Particle.Eta',
+         'phi': 'Particle/Particle.Phi',
+         'mass': 'Particle/Particle.Mass'
+       },
+       {
+         'pt': 'Particle/Particle.PT',
+         'eta': 'Particle/Particle.Eta',
+         'phi': 'Particle/Particle.Phi',
+         'mass': 'Particle/Particle.Mass',
+         'D1': 'Particle/Particle.D1',
+         'D2': 'Particle/Particle.D2',
+         'M1': 'Particle/Particle.M1',
+         'M2': 'Particle/Particle.M2',
+         'PID': 'Particle/Particle.PID',
+         'Status': 'Particle/Particle.Status'
+       },
+       lambda p,v:(v["Status"] > 19) & (v["Status"] < 30), # the cut, status 20-29 means the particle from hard process
+        {   
+            # For genpart, please note that p->hardprocess, but not lastcopy, v->lastcopy from hardprocess 
+            # Always store last copy.
+            "genpart_pt":lambda p,v:   v['pt'],
+            "genpart_eta": lambda p,v: v['eta'],
+            "genpart_phi": lambda p,v: v['phi'],
+            "genpart_mass": lambda p,v: v['mass'],
+            "genpart_index": lambda p,v: v['index'], # Define in other place
+            "genpart_M1":  lambda p,v:  v['M1'],
+            "genpart_M2":  lambda p,v:  v['M2'],
+            "genpart_PID": lambda p,v:  v['PID'],
+            "genpart_Status": lambda p,v: v['Status']
+        }, # prepare the output variables
+       ["genpart_pt", "genpart_eta", "genpart_phi", "genpart_mass", "genpart_index", "genpart_M1", "genpart_M2", "genpart_PID", "genpart_Status"]# the actual saved one and the order
+     ],
     "event":[ # hardcorded name. not change
         {
             "met_met":"MissingET/MissingET.MET",
@@ -128,6 +164,26 @@ SCHEMA={
         ["met_met","met_phi","weight",], # the actual saved one and the order
     ], 
 }
+
+def find_last_copy(seed, particle_collection):
+    PID_base = seed.PID
+    M1_base = seed.M1
+    M2_base = seed.M2
+    Status_base = seed.Status
+    search = True
+    mask = (seed.PID==seed.PID)
+    total_count = ak.sum(ak.flatten(mask))
+    while search:
+        new_seed = particle_collection[seed.D1]
+        mask = ak.where(mask, ~(new_seed.index == seed.index), mask)
+        mask = ak.where(mask, new_seed.PID == seed.PID, mask)
+        search = ak.any(ak.flatten(mask))
+        seed = ak.where(mask, new_seed, seed)
+        print("[GenParticle] Finding last copy -> remaining: {}/{}".format(ak.sum(ak.flatten(mask)), total_count))
+    seed["M1"] = M1_base
+    seed["M2"] = M2_base
+    seed["Status"] = Status_base
+    return seed
 
 def read_file(
         filepath,
@@ -157,10 +213,23 @@ def read_file(
         mask=cut(p4,table2)
         p4=p4[mask]
         table2=table2[mask] if len(table2)>0 else {}
-        #
         ret_dict={k:v(p4,table2) for k,v in s_dict.items()}
         ret_np=np.stack([ak.to_numpy(_pad(ret_dict[n], maxlen=max_len)) for n in o_list], axis=-1)
         return ret_np,ret_dict
+
+    def read_fixed_length_gen_objects(tree, max_len, v_dict, a_dict, cut, s_dict, o_list, matched_object):
+        table1 = tree.arrays(v_dict.values())
+        p4  = vector.zip({k: table1[v] for k, v in v_dict.items()})
+        table2 = tree.arrays(a_dict.values())
+        particles = ak.zip({k: table2[v] for k, v in a_dict.items()})
+        particles["index"] = ak.local_index(particles) 
+        mask = cut(p4, particles)
+        p4   = p4[mask]
+        table_HardProcess = particles[mask]
+        table_HardProcess_isLastCopy = find_last_copy(table_HardProcess, particles)
+        ret_dict = {k:v(p4, table_HardProcess_isLastCopy) for k,v in s_dict.items()}
+        ret_np   = np.stack([ak.to_numpy(_pad(ret_dict[n], maxlen=max_len)) for n in o_list], axis=-1)
+        return ret_np, ret_dict
 
     def read_event(tree,objects,i_dict,cut,s_dict,o_list):
         table2=tree.arrays(i_dict.keys(),aliases=i_dict)
@@ -174,10 +243,13 @@ def read_file(
     tree = uproot.open(filepath)['Delphes'] # not load all the branches.
     
     # later proably dict could be ak record?
-    objects={k:read_fixed_length_objects(tree,*scheme[k]) for k in scheme.keys() if k!="event"}
+    objects={k:read_fixed_length_objects(tree,*scheme[k]) for k in scheme.keys() if ((k!="event") & (k!="genparticles"))}
+    gen_objects = read_fixed_length_gen_objects(tree, *scheme["genparticles"], objects)
+
     event=read_event(tree,objects,*scheme["event"])
     
     x_objects={k:object[0] for k,object in objects.items()}
+    x_objects['genpart'] = gen_objects[0]
     x_event=event[0]
     
     y=None # remain for later usage


### PR DESCRIPTION
Hi @qibin2020 , here is the update for storing truth information and sorry for late PR. Spend some time figuring out the details of pythia stuff. There are still some issues that could be improved, but I think it would be better to first make a PR in case you might want to test and proceed to next step.
- Currently the "index", "M1", "M2" of gen particle is not the local index of the collections after selection. Still thinking how to do it swiftly to map from old indexing (before selection) to new local indexing (after selection). In any case, the labeling is consistent with each other.
- The "index" stuffs are currently stored in float as it should be stored with other gen particle properties and numpy array does not support mixing dtype. 
- Should we add genmatching of reco level stuff in the code? It is necessary for the pairing, but quite time consuming. Depending on the strategy, we could perform it here or afterward.